### PR TITLE
Add TakeAI to AI tools directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 | [Toucu AI](https://toucu.ai) | AI工具触手可及的导航平台 | 13 |  |
 | [Victrays](https://victrays.com) | AI工具和资源的聚合网站 | 14 |  |
 | [Supertools](https://supertools.therundown.ai) | 超级AI工具导航和评估平台 | 56 | 314100 |
+| [TakeAI](https://takeai.org) | 发现和探索最好的AI工具和应用 | 25 | 10000 |
 | [Aitoolnet](https://www.aitoolnet.com) | AI工具网络和资源中心 | 54 | 61300 |
 | [Al Marketing Directory](https://aimarketing.directory) | AI营销工具目录 | 8 |  |
 | [Marsx's Al Startups](https://www.marsx.dev/ai-startups) | AI创业公司和工具展示平台 | 43 |  |


### PR DESCRIPTION
Adding TakeAI (https://takeai.org) to the list. TakeAI is a comprehensive directory for discovering AI tools.