### PR TITLE
Add AIWget to AI工具收录导航

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 |------|------|------|------|
 | [Magicbox](https://magicbox.tools) | AI工具和资源的聚合平台 | 71 | 6000 |
 | [AI Best Tools](https://aibest.tools/) | 精选AI工具目录 | 46 | 6000 |
-| [AIWget](https://aiwget.com) | 面向AI Agent、自动化工具、创意AI产品和开发者软件的精选目录 |  |  |
+| [AIWget](https://aiwget.com) | 面向AI Agent、自动化工具、创意AI产品和开发者软件的精选目录 | 32 | 1000 |
 | [Best AI Tools Directory](https://www.bestaitoolsforthat.com/) | 精选AI工具目录 | 31 |  |
 | [SaaS AI Tools](https://saasaitools.com) | SaaS和AI工具的综合目录 | 57 | 14300 |
 | [Future Tools](https://futuretools.io) | 发现和探索新兴AI工具 | 61 | 528800 |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 |------|------|------|------|
 | [Magicbox](https://magicbox.tools) | AI工具和资源的聚合平台 | 71 | 6000 |
 | [AI Best Tools](https://aibest.tools/) | 精选AI工具目录 | 46 | 6000 |
+| [AIWget](https://aiwget.com) | 面向AI Agent、自动化工具、创意AI产品和开发者软件的精选目录 |  |  |
 | [Best AI Tools Directory](https://www.bestaitoolsforthat.com/) | 精选AI工具目录 | 31 |  |
 | [SaaS AI Tools](https://saasaitools.com) | SaaS和AI工具的综合目录 | 57 | 14300 |
 | [Future Tools](https://futuretools.io) | 发现和探索新兴AI工具 | 61 | 528800 |


### PR DESCRIPTION
在「AI工具收录导航」表格新增 AIWget。

AIWget 是一个面向 AI Agent、工作流自动化工具、创意 AI 产品和开发者软件的精选目录，符合本仓库对 AI 工具导航站的收录范围。

- 网站：https://aiwget.com
- 提交入口：https://aiwget.com/submit
- DR / MV：32/1000
- 披露：我是 AIWget 的创始人

本次仅修改 README.md 并新增一行，沿用现有四列表格格式。感谢维护这个项目！